### PR TITLE
Fix status and create

### DIFF
--- a/lib/beaker/hypervisor/lima_helper.rb
+++ b/lib/beaker/hypervisor/lima_helper.rb
@@ -57,7 +57,7 @@ module Beaker
     def start(vm_name, cfg = {})
       case status(vm_name)
       when ''
-        return create(vm_name, cfg)
+        create(vm_name, cfg)
       when 'Running'
         @logger.debug("'#{vm_name}' is running already, skipping...")
         return true
@@ -82,9 +82,10 @@ module Beaker
         # Write config to a temporary YAML file and pass it to limactl later
         safe_name = Shellwords.escape(vm_name)
         tmpfile = Tempfile.new(["lima_#{safe_name}", '.yaml'])
+        vm_preset = { "cpus" => 2, "memory" => "2GiB", "disk" => "20GiB" }.merge(cfg[:config] || {})
         # config has symbolized keys by default. So .to_yaml will write keys as :symbols.
         # Keys should be stringified to avoid this so Lima can parse the YAML properly.
-        tmpfile.write(stringify_keys_recursively(cfg[:config]).to_yaml)
+        tmpfile.write(stringify_keys_recursively(vm_preset).to_yaml)
         tmpfile.close
 
         # Validate the config
@@ -96,7 +97,7 @@ module Beaker
         raise LimaError, 'At least one of url/template/config parameters must be specified'
       end
 
-      lima_cmd = [@limactl, 'start', "--name=#{vm_name}", "--timeout=#{@timeout}s", cfg_url]
+      lima_cmd = [@limactl, 'create', "--name=#{vm_name}", cfg_url]
       _, stderr_str, status = Open3.capture3(*lima_cmd)
       tmpfile&.unlink # Delete tmpfile if any
 

--- a/lib/beaker/hypervisor/lima_helper.rb
+++ b/lib/beaker/hypervisor/lima_helper.rb
@@ -48,7 +48,13 @@ module Beaker
       lima_cmd = [@limactl, 'list', '--format', '{{ .Status }}', vm_name]
       stdout_str, stderr_str, status = Open3.capture3(*lima_cmd)
       unless status.success?
-        raise LimaError, "`#{lima_cmd.join(' ')}` failed with status #{status.exitstatus}: #{stderr_str}"
+        case status.exitstatus
+        when 1
+          # VM not found, continue without raising
+          @logger.debug("VM '#{vm_name}' not found when checking status")
+        else
+          raise LimaError, "`#{lima_cmd.join(' ')}` failed with status #{status.exitstatus}: #{stderr_str}"
+        end
       end
 
       stdout_str.chomp
@@ -82,7 +88,7 @@ module Beaker
         # Write config to a temporary YAML file and pass it to limactl later
         safe_name = Shellwords.escape(vm_name)
         tmpfile = Tempfile.new(["lima_#{safe_name}", '.yaml'])
-        vm_preset = { "cpus" => 2, "memory" => "2GiB", "disk" => "20GiB" }.merge(cfg[:config] || {})
+        vm_preset = { 'cpus' => 2, 'memory' => '2GiB', 'disk' => '20GiB' }.merge(cfg[:config] || {})
         # config has symbolized keys by default. So .to_yaml will write keys as :symbols.
         # Keys should be stringified to avoid this so Lima can parse the YAML properly.
         tmpfile.write(stringify_keys_recursively(vm_preset).to_yaml)

--- a/spec/beaker/hypervisor/lima_helper_spec.rb
+++ b/spec/beaker/hypervisor/lima_helper_spec.rb
@@ -94,10 +94,15 @@ module Beaker
         it 'creates the VM' do
           allow(lima_helper).to receive(:status).and_return(vm_status)
           allow(lima_helper).to receive(:create).with(vm_name, {}).and_return(true)
+          allow(Open3).to receive(:capture3).with('limactl', 'start', "--timeout=#{options[:timeout]}s", vm_name)
+                                            .and_return([vm_status, '', lima_success])
 
           result = lima_helper.start(vm_name)
           expect(lima_helper).to have_received(:status).once
           expect(lima_helper).to have_received(:create).with(vm_name, {}).once
+          expect(Open3).to have_received(:capture3)
+            .with('limactl', 'start', "--timeout=#{options[:timeout]}s", vm_name)
+            .once
           expect(result).to be true
         end
       end
@@ -109,12 +114,12 @@ module Beaker
 
         it 'creates the VM' do
           allow(Open3).to receive(:capture3)
-            .with('limactl', 'start', "--name=#{vm_name}", "--timeout=#{options[:timeout]}s", cfg[:url])
+            .with('limactl', 'create', "--name=#{vm_name}", cfg[:url])
             .and_return(['', '', lima_success])
 
           result = lima_helper.create(vm_name, cfg)
           expect(Open3).to have_received(:capture3)
-            .with('limactl', 'start', "--name=#{vm_name}", "--timeout=#{options[:timeout]}s", cfg[:url])
+            .with('limactl', 'create', "--name=#{vm_name}", cfg[:url])
             .once
           expect(result).to be true
         end
@@ -138,13 +143,13 @@ module Beaker
           allow(Open3).to receive(:capture3).with('limactl', 'validate', saved_path)
                                             .and_return(['', '', lima_success])
           allow(Open3).to receive(:capture3)
-            .with('limactl', 'start', "--name=#{vm_name}", "--timeout=#{options[:timeout]}s", saved_path)
+            .with('limactl', 'create', "--name=#{vm_name}", saved_path)
             .and_return(['', '', lima_success])
 
           result = lima_helper.create(vm_name, cfg)
           expect(Open3).to have_received(:capture3).with('limactl', 'validate', saved_path).once
           expect(Open3).to have_received(:capture3)
-            .with('limactl', 'start', "--name=#{vm_name}", "--timeout=#{options[:timeout]}s", saved_path)
+            .with('limactl', 'create', "--name=#{vm_name}", saved_path)
             .once
           expect(result).to be true
         end


### PR DESCRIPTION
when check status on missing vm it raise an error becaus limactl list vm_name return exitcode 1 on unmatched vm
the I update the create function to just create the vm and start it in the start function, also create use default for cpu, ram and disk to spawn small vm.